### PR TITLE
no_std

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,18 @@ hound = "3.4.0"
 quick-xml = "0.18.1"
 clap = "2.33.1"
 chrono = "0.4.15"
+
+[features]
+# default = ["std"]
+std = []
+alloc = []
+
+[[bin]]
+name = "x3"
+path = "bin/x3.rs"
+required-features = ["std"]
+
+[[bin]]
+name = "wav_to_str"
+path = "bin/wav_to_str.rs"
+required-features = ["std"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,10 +33,10 @@ alloc = []
 
 [[bin]]
 name = "x3"
-path = "bin/x3.rs"
+path = "src/bin/x3.rs"
 required-features = ["std"]
 
 [[bin]]
 name = "wav_to_str"
-path = "bin/wav_to_str.rs"
+path = "src/bin/wav_to_str.rs"
 required-features = ["std"]

--- a/src/bitpacker.rs
+++ b/src/bitpacker.rs
@@ -50,7 +50,7 @@ pub struct BitPacker<'a> {
 }
 
 impl<'a> BitPacker<'a> {
-    pub fn new(array: &'a mut [u8]) -> BitPacker {
+    pub fn new(array: &'a mut [u8]) -> BitPacker<'a> {
         BitPacker {
             array,
             p_byte: 0,

--- a/src/bytereader.rs
+++ b/src/bytereader.rs
@@ -77,7 +77,8 @@ impl<'a> ByteReader<'a> {
     }
     false
   }
-
+  
+  #[cfg(any(feature = "alloc", feature = "std"))]
   pub fn extract(&self, p_start: usize, p_end: usize) -> Result<Vec<u8>, BitPackError> {
     if p_start > self.array.len() || p_end > self.array.len() {
       Err(BitPackError::ArrayEndReached)

--- a/src/bytereader.rs
+++ b/src/bytereader.rs
@@ -43,7 +43,7 @@ pub struct ByteReader<'a> {
 }
 
 impl<'a> ByteReader<'a> {
-  pub fn new(array: &'a [u8]) -> ByteReader {
+  pub fn new(array: &'a [u8]) -> ByteReader<'a> {
     ByteReader { array, p_byte: 0 }
   }
 

--- a/src/bytereader.rs
+++ b/src/bytereader.rs
@@ -24,6 +24,9 @@ use crate::bitpacker::BitPackError;
 use crate::byteorder::{BigEndian, ByteOrder, LittleEndian};
 use crate::crc::crc16;
 
+#[cfg(any(feature = "alloc", feature = "std"))]
+use alloc::vec::Vec;
+
 //
 // ######                       ######
 // #     # #     # ##### ###### #     # ######   ##   #####  ###### #####

--- a/src/decodefile.rs
+++ b/src/decodefile.rs
@@ -23,6 +23,8 @@
 use std::fs::File;
 use std::io::{prelude::*, BufReader};
 use std::path;
+use std::vec::Vec;
+
 
 // externs
 use crate::hound;

--- a/src/decodefile.rs
+++ b/src/decodefile.rs
@@ -23,6 +23,9 @@
 use std::fs::File;
 use std::io::{prelude::*, BufReader};
 use std::path;
+use std::println;
+use std::string::String;
+use std::vec;
 use std::vec::Vec;
 
 

--- a/src/encodefile.rs
+++ b/src/encodefile.rs
@@ -23,6 +23,7 @@
 use std::fs::File;
 use std::io::prelude::*;
 use std::path;
+use std::vec::Vec;
 
 // externs
 use crate::hound;

--- a/src/encodefile.rs
+++ b/src/encodefile.rs
@@ -56,9 +56,8 @@ pub fn wav_to_x3a<P: AsRef<path::Path>>(wav_filename: P, x3a_filename: P) -> Res
   let params = x3::Parameters::default();
   let sample_rate = reader.spec().sample_rate;
 
-  // FIXME: This is pretty memory inefficient.  Should process bit by bit
-  let samples = reader.samples::<i16>().map(|x| x.unwrap()).collect::<Vec<i16>>();
-  let first_channel = x3::Channel::new(0, &samples[0..], sample_rate, params);
+  let samples = reader.samples::<i16>().map(|x| x.unwrap());
+  let first_channel = x3::Channel::new(0, samples, sample_rate, params);
 
   let num_samples = first_channel.wav.len();
   let mut x3_out = vec![0u8; num_samples * 2];

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -61,7 +61,7 @@ pub fn encode<'a, I>(channels: &mut [&mut x3::IterChannel<I>], bp: &mut BitPacke
   let stats: &mut [usize; 6] = &mut [0; 6];
 
 
-  #[cfg(any(feature = "alloc", feature = "std"))]
+  #[cfg(any(feature = "alloc", feature = "std"))]{
     loop{
       let frame_buffer = wav.by_ref().take(samples_per_frame).collect::<Vec<i16>>();
       if frame_buffer.len() == 0 {

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -583,14 +583,14 @@ mod tests {
     let num_samples = wav.len();
 
     // Create the channel data
-    let first_channel = x3::IterChannel::new(0, wav.iter(), sample_rate, params);
+    let mut first_channel = x3::IterChannel::new(0, wav.into_iter(), sample_rate, params);
 
     // Create the output data
     let x3_len = num_samples * 2;
     let mut x3_out = vec![0u8; x3_len];
     let bp = &mut BitPacker::new(&mut x3_out); // Packer where x3 compressed data is stored.
 
-    encoder::encode(&[&first_channel], bp).unwrap();
+    encoder::encode(&mut [&mut first_channel], bp).unwrap();
 
     // Get the bytes
     let _x3_bytes = bp.as_bytes();

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -59,16 +59,18 @@ pub fn encode(channels: &[&x3::Channel], bp: &mut BitPacker) -> Result<(), X3Err
     num_samples -= encode_num_samples;
   }
 
-  let t = (stats[0] + stats[1] + stats[2] + stats[3] + stats[4] + stats[5]) as f32;
-  println!(
-    "\nStatistics:\n  Rice-0: {:.4}%\n  Rice-1: {:.4}%\n  Rice-2: {:.4}%\n  Rice-3: {:.4}%\n  BFP: {:.4}%\n  Pass-through {:.4}%\n",
-    (stats[0] as f32 / t) * 100.0,
-    (stats[1] as f32 / t) * 100.0,
-    (stats[2] as f32 / t) * 100.0,
-    (stats[3] as f32 / t) * 100.0,
-    (stats[4] as f32 / t) * 100.0,
-    (stats[5] as f32 / t) * 100.0
-  );
+  #[cfg(feature = "std")]{
+    let t = (stats[0] + stats[1] + stats[2] + stats[3] + stats[4] + stats[5]) as f32;
+    println!(
+      "\nStatistics:\n  Rice-0: {:.4}%\n  Rice-1: {:.4}%\n  Rice-2: {:.4}%\n  Rice-3: {:.4}%\n  BFP: {:.4}%\n  Pass-through {:.4}%\n",
+      (stats[0] as f32 / t) * 100.0,
+      (stats[1] as f32 / t) * 100.0,
+      (stats[2] as f32 / t) * 100.0,
+      (stats[3] as f32 / t) * 100.0,
+      (stats[4] as f32 / t) * 100.0,
+      (stats[5] as f32 / t) * 100.0
+    );
+  }
 
   Ok(())
 }
@@ -328,11 +330,16 @@ fn x3_encode_block(
 
 #[cfg(test)]
 mod tests {
+  
   use crate::bitpacker::BitPacker;
   use crate::encoder;
   use crate::encoder::{encode_frame, x3_encode_block};
   use crate::x3;
   use crate::x3::Parameters;
+  
+  extern crate std;
+  use std::vec;
+  use std::vec::Vec;
 
   const NUM_SAMPLES: usize = 0x0eff;
 

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -69,7 +69,7 @@ pub fn encode<'a, I>(channels: &mut [&mut x3::IterChannel<I>], bp: &mut BitPacke
       break;
     }
 
-    encode_frame(&frame_buffer[..frame_length], bp, &ch.params, stats)?;
+    encode_frame(&frame_buffer[..frame_length+1], bp, &ch.params, stats)?;
   }
 
   #[cfg(feature = "std")]{

--- a/src/error.rs
+++ b/src/error.rs
@@ -19,6 +19,8 @@
  *                                                                        *
  **************************************************************************/
 
+pub type Result<T> = core::result::Result<T, X3Error>;
+
 // We derive `Debug` because all types should probably derive `Debug`.
 // This gives us a reasonable human readable description of `CliError` values.
 #[derive(Debug)]

--- a/src/error.rs
+++ b/src/error.rs
@@ -23,6 +23,7 @@
 // This gives us a reasonable human readable description of `CliError` values.
 #[derive(Debug)]
 pub enum X3Error {
+  #[cfg(feature = "std")]
   Io(std::io::Error),
   Hound(hound::Error),
   BitPack(crate::bitpacker::BitPackError),
@@ -56,6 +57,7 @@ pub enum X3Error {
   FrameDecodeUnexpectedEnd,      // The BitReader has less bytes than the size of the header, but still expects a frame.
 }
 
+#[cfg(feature = "std")]
 impl From<std::io::Error> for X3Error {
   fn from(err: std::io::Error) -> X3Error {
     X3Error::Io(err)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,9 @@
 #[cfg(feature = "std")]
 extern crate std;
 
+#[cfg(any(feature = "alloc", feature = "std"))]
+extern crate alloc;
+
 extern crate byteorder;
 extern crate hound;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,3 +38,4 @@ pub mod encodefile;
 pub mod encoder;
 pub mod error;
 pub mod x3;
+mod utils;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,10 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.   *
  *                                                                        *
  **************************************************************************/
+#![no_std]
+
+#[cfg(feature = "std")]
+extern crate std;
 
 extern crate byteorder;
 extern crate hound;
@@ -26,8 +30,10 @@ pub mod bitpacker;
 pub mod bitreader;
 pub mod bytereader;
 pub mod crc;
+#[cfg(feature = "std")]
 pub mod decodefile;
 pub mod decoder;
+#[cfg(feature = "std")]
 pub mod encodefile;
 pub mod encoder;
 pub mod error;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,20 @@
+#[inline(always)]
+#[cold]
+pub const fn cold() {}
+
+#[inline(always)]
+#[allow(unused)]
+pub const fn likely(b: bool) -> bool {
+    if !b {
+        cold();
+    }
+    b
+}
+
+#[inline(always)]
+pub const fn _unlikely(b: bool) -> bool {
+    if b {
+        cold();
+    }
+    b
+}

--- a/src/x3.rs
+++ b/src/x3.rs
@@ -44,8 +44,8 @@ impl<'a> Channel<'a> {
   }
 }
 
-pub struct IterChannel<'a, I>
-  where  I: Iterator<Item = &'a i16>
+pub struct IterChannel<I>
+  where  I: Iterator<Item = i16>
 {
   pub id: u16,            // The channel number
   pub wav: I,         // Raw sample iterator
@@ -53,8 +53,8 @@ pub struct IterChannel<'a, I>
   pub params: Parameters, // X3 encoding parameters
 }
 
-impl<'a, I> IterChannel<'a, I> 
-  where I: Iterator<Item = &'a i16>
+impl<'a, I> IterChannel<I> 
+  where I: Iterator<Item =i16>
 {
   pub fn new(id: u16, wav: impl IntoIterator<IntoIter = I>, sample_rate: u32, params: Parameters) -> Self {
     IterChannel {
@@ -75,6 +75,7 @@ pub struct X3aSpec {
   /// The number of channels in use
   pub channels: u8,
 }
+
 pub struct Parameters {
   pub block_len: usize,
   pub blocks_per_frame: usize,

--- a/src/x3.rs
+++ b/src/x3.rs
@@ -44,6 +44,27 @@ impl<'a> Channel<'a> {
   }
 }
 
+pub struct IterChannel<'a, I>
+  where  I: Iterator<Item = &'a i16>
+{
+  pub id: u16,            // The channel number
+  pub wav: I,         // Raw sample iterator
+  pub sample_rate: u32,   // The sample rate in Hz
+  pub params: Parameters, // X3 encoding parameters
+}
+
+impl<'a, I> IterChannel<'a, I> 
+  where I: Iterator<Item = &'a i16>
+{
+  pub fn new(id: u16, wav: impl IntoIterator<IntoIter = I>, sample_rate: u32, params: Parameters) -> Self {
+    IterChannel {
+      id,
+      wav: wav.into_iter(),
+      sample_rate,
+      params,
+    }
+  }
+}
 pub struct X3aSpec {
   /// The number of samples per second.
   pub sample_rate: u32,

--- a/test/test_wavs.sh
+++ b/test/test_wavs.sh
@@ -40,7 +40,9 @@ if [ -z ${SOUND_DIR} ] || [ ! -d ${SOUND_DIR} ]; then
 fi
 
 # build it
-cargo build --${TARGET}
+cargo build --${TARGET} --bin="x3" --features="std"
+cargo build --${TARGET} --bin="wav_to_str" --features="std"
+
 
 TEMP_X3A=$(mktemp).x3a
 trap "rm -f $TEMP_X3A" 0 2 3 15
@@ -72,6 +74,7 @@ do
   $W2S --wav $TEMP_WAV > "${TEMP_WAV_STR_TEST}"
   WAV_DIFF=$(cmp "${TEMP_WAV_STR_ORIG}" "${TEMP_WAV_STR_TEST}")
   if [ -n "${WAV_DIFF}" ]; then
+    vbindiff "${WAV}" "${TEMP_WAV}"
     echo "  TEST FAILED"
     echo ${WAV_DIFF}
     exit 1


### PR DESCRIPTION
Make library `no_std` compatible with optional `std` feature (for non-embedded systems) and `alloc` features (for embedded systems with heap implementations).