### PR TITLE
implement multichannel decode

### DIFF
--- a/benches/x3-bench/main.rs
+++ b/benches/x3-bench/main.rs
@@ -22,7 +22,7 @@
 use std::vec;
 use criterion::{Criterion, Throughput, criterion_group, criterion_main};
 use x3::bytewriter::SliceByteWriter;
-use x3::{decoder, x3};
+use x3::{decoder};
 use x3::encoder::encode_frame;
 use x3::streamencoder::StreamEncoder;
 
@@ -100,7 +100,7 @@ fn decode(c: &mut Criterion, scale: f32) {
   // Benchmark the time and throughput of decoding
   bench_thrpt(c, &label, NUM_SAMPLES * 2, move || {
     let mut wav_output = [0i16; NUM_SAMPLES];
-    decoder::decode_frame::<{x3::x3::Parameters::MAX_CHANNEL_COUNT}, {x3::x3::Parameters::MAX_BLOCK_LENGTH}>(
+    decoder::decode_frame(
       &x3_output[x3::x3::FrameHeader::LENGTH..],
       &mut wav_output,
       &params,

--- a/benches/x3-bench/main.rs
+++ b/benches/x3-bench/main.rs
@@ -22,8 +22,9 @@
 use std::vec;
 use criterion::{Criterion, Throughput, criterion_group, criterion_main};
 use x3::bytewriter::SliceByteWriter;
-use x3::decoder;
+use x3::{decoder, x3};
 use x3::encoder::encode_frame;
+use x3::streamencoder::StreamEncoder;
 
 const NUM_SAMPLES: usize = 16 * 1024;
 
@@ -61,7 +62,23 @@ fn encode(c: &mut Criterion, scale: f32) {
     let stats: &mut [usize; 6] = &mut [0; 6];
     encode_frame(&wav, writer, params, stats).unwrap();
   });
+}
 
+fn stream_encode(c: &mut Criterion, scale: f32) {
+  // Create the WAV buffer and the label for the benchmark
+  let wav = create_wav_buffer(scale);
+  let label = format!("stream_encode_frame - {}", scale);
+
+  // Benchmark the time and throughput of encoding
+  bench_thrpt(c, &label, wav.len() * 2, move || {
+    let x3_output: &mut [u8] = &mut [0u8; NUM_SAMPLES * 2];
+    let writer = &mut SliceByteWriter::new(x3_output);
+    let params = &x3::x3::Parameters::default();
+
+    let mut encoder : StreamEncoder<_, 1, {x3::x3::Parameters::DEFAULT_BLOCK_LENGTH}> = StreamEncoder::new(writer, params);
+    let _ = encoder.process_interleaved(wav.iter());
+    let _ = encoder.close();
+  });
 }
 
 fn decode(c: &mut Criterion, scale: f32) {
@@ -83,7 +100,7 @@ fn decode(c: &mut Criterion, scale: f32) {
   // Benchmark the time and throughput of decoding
   bench_thrpt(c, &label, NUM_SAMPLES * 2, move || {
     let mut wav_output = [0i16; NUM_SAMPLES];
-    decoder::decode_frame(
+    decoder::decode_frame::<{x3::x3::Parameters::MAX_CHANNEL_COUNT}, {x3::x3::Parameters::MAX_BLOCK_LENGTH}>(
       &x3_output[x3::x3::FrameHeader::LENGTH..],
       &mut wav_output,
       &params,
@@ -98,6 +115,10 @@ fn criterion_benchmark(c: &mut Criterion) {
   encode(c, 0.0);   // Targets Rice-0 encoding
   encode(c, 0.03);  // Targets Rice-0, Rice-1, and Rice-3 encoding
   encode(c, 0.5);   // Targets BPF encoding
+
+  stream_encode(c, 0.0);   // Targets Rice-0 encoding
+  stream_encode(c, 0.03);  // Targets Rice-0, Rice-1, and Rice-3 encoding
+  stream_encode(c, 0.5);   // Targets BPF encoding
 
   decode(c, 0.0);   // Targets Rice-0 encoding
   decode(c, 0.03);  // Targets Rice-0, Rice-1, and Rice-3 encoding

--- a/src/decodefile.rs
+++ b/src/decodefile.rs
@@ -125,10 +125,7 @@ impl X3aReader {
     let x3_bytes = &mut self.read_buf[0..frame_header.payload_len];
 
     // Do the decoding
-    match decoder::decode_frame::<
-      {x3::Parameters::MAX_CHANNEL_COUNT}, 
-      {x3::Parameters::MAX_BLOCK_LENGTH}
-    >(x3_bytes, wav_buf, &self.spec.params, samples) {
+    match decoder::decode_frame(x3_bytes, wav_buf, &self.spec.params, samples) {
       Ok(result) => Ok(Some(result)),
       Err(err) => {
         self.frame_errors += 1;

--- a/src/decodefile.rs
+++ b/src/decodefile.rs
@@ -125,7 +125,10 @@ impl X3aReader {
     let x3_bytes = &mut self.read_buf[0..frame_header.payload_len];
 
     // Do the decoding
-    match decoder::decode_frame(x3_bytes, wav_buf, &self.spec.params, samples) {
+    match decoder::decode_frame::<
+      {x3::Parameters::MAX_CHANNEL_COUNT}, 
+      {x3::Parameters::MAX_BLOCK_LENGTH}
+    >(x3_bytes, wav_buf, &self.spec.params, samples) {
       Ok(result) => Ok(Some(result)),
       Err(err) => {
         self.frame_errors += 1;

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -33,25 +33,42 @@ pub enum FrameTest {
   NotFrame,
 }
 
-pub fn decode_frame(
+pub fn decode_frame<
+  const MAX_CHANNEL_COUNT: usize,
+  const MAX_BLOCK_LENGTH: usize,
+>(
   x3_bytes: &[u8],
   wav_buf: &mut [i16],
   params: &x3::Parameters,
   samples: usize,
 ) -> Result<usize, X3Error> {
-  let mut last_wav = BigEndian::read_i16(x3_bytes);
+  let mut last_wav = [0i16; MAX_CHANNEL_COUNT];
   let mut p_wav = 0;
-  wav_buf[p_wav] = last_wav;
-  p_wav += 1;
-  let br = &mut BitReader::new(&x3_bytes[2..]);
+  for ch in 0..params.channel_count {
+    last_wav[ch] = BigEndian::read_i16(&x3_bytes[2*ch..]);
+    wav_buf[p_wav] = last_wav[ch];
+    p_wav += 1;
+  }
+
+  let br = &mut BitReader::new(&x3_bytes[2*params.channel_count..]);
   let mut remaining_samples = samples - 1;
 
   while remaining_samples > 0 {
     let block_len = core::cmp::min(remaining_samples, params.block_len);
-    decode_block(br, &mut wav_buf[p_wav..(p_wav + block_len)], &mut last_wav, params)?;
 
+    // Collect a block for each channel
+    let mut decoded_block_buffers = [[0i16; MAX_BLOCK_LENGTH]; MAX_CHANNEL_COUNT];
+    for ch in 0..params.channel_count {
+      decode_block(br, &mut decoded_block_buffers[ch][..block_len], &mut last_wav[ch], params)?;
+    }
+    // De interlace the channels
+    for i in 0..block_len {
+      for ch in 0..params.channel_count {
+        wav_buf[p_wav] = decoded_block_buffers[ch][i];
+        p_wav += 1;
+      }
+    }
     remaining_samples -= block_len;
-    p_wav += block_len;
   }
 
   Ok(p_wav)
@@ -384,7 +401,7 @@ mod tests {
 
     // Do the decoding
     let wav_output = &mut [0i16; WAV_INPUT.len()];
-    decoder::decode_frame(x3_output, wav_output, &params, samples).unwrap();
+    decoder::decode_frame::<{x3::Parameters::MAX_CHANNEL_COUNT}, {x3::Parameters::MAX_BLOCK_LENGTH}>(x3_output, wav_output, &params, samples).unwrap();
 
     assert_eq!(WAV_INPUT, wav_output);
   }

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -33,16 +33,13 @@ pub enum FrameTest {
   NotFrame,
 }
 
-pub fn decode_frame<
-  const MAX_CHANNEL_COUNT: usize,
-  const MAX_BLOCK_LENGTH: usize,
->(
+pub fn decode_frame(
   x3_bytes: &[u8],
   wav_buf: &mut [i16],
   params: &x3::Parameters,
   samples: usize,
 ) -> Result<usize, X3Error> {
-  let mut last_wav = [0i16; MAX_CHANNEL_COUNT];
+  let mut last_wav = [0i16; x3::Parameters::MAX_CHANNEL_COUNT];
   let mut p_wav = 0;
   for ch in 0..params.channel_count {
     last_wav[ch] = BigEndian::read_i16(&x3_bytes[2*ch..]);
@@ -57,11 +54,12 @@ pub fn decode_frame<
     let block_len = core::cmp::min(remaining_samples, params.block_len);
 
     // Collect a block for each channel
-    let mut decoded_block_buffers = [[0i16; MAX_BLOCK_LENGTH]; MAX_CHANNEL_COUNT];
+    let mut decoded_block_buffers = [[0i16; x3::Parameters::MAX_BLOCK_LENGTH]; x3::Parameters::MAX_CHANNEL_COUNT];
     for ch in 0..params.channel_count {
       decode_block(br, &mut decoded_block_buffers[ch][..block_len], &mut last_wav[ch], params)?;
     }
-    // De interlace the channels
+
+    // Interleave the channel samples
     for i in 0..block_len {
       for ch in 0..params.channel_count {
         wav_buf[p_wav] = decoded_block_buffers[ch][i];
@@ -401,7 +399,7 @@ mod tests {
 
     // Do the decoding
     let wav_output = &mut [0i16; WAV_INPUT.len()];
-    decoder::decode_frame::<{x3::Parameters::MAX_CHANNEL_COUNT}, {x3::Parameters::MAX_BLOCK_LENGTH}>(x3_output, wav_output, &params, samples).unwrap();
+    decoder::decode_frame(x3_output, wav_output, &params, samples).unwrap();
 
     assert_eq!(WAV_INPUT, wav_output);
   }


### PR DESCRIPTION
# Description

Implements multichannel decoding

# Benchmark

Current multichannel benchmark show a significant performance regression. This is likely due to decoded samples having to be copied to an additional temporary buffer to allow the interleaved blocks of multichannel x3 to be converted into interleaved samples for the wav output.

```
decode_frame - 0/throughput
                        time:   [122.40 µs 129.99 µs 138.20 µs]
                        thrpt:  [226.12 MiB/s 240.40 MiB/s 255.30 MiB/s]
                 change:
                        time:   [+45.555% +53.491% +62.664%] (p = 0.00 < 0.05)
                        thrpt:  [−38.523% −34.850% −31.297%]
                        Performance has regressed.
Found 15 outliers among 100 measurements (15.00%)
  5 (5.00%) high mild
  10 (10.00%) high severe

decode_frame - 0.03/throughput
                        time:   [131.39 µs 131.84 µs 132.30 µs]
                        thrpt:  [236.21 MiB/s 237.02 MiB/s 237.83 MiB/s]
                 change:
                        time:   [+34.766% +41.457% +48.946%] (p = 0.00 < 0.05)
                        thrpt:  [−32.862% −29.307% −25.797%]
                        Performance has regressed.
Found 12 outliers among 100 measurements (12.00%)
  2 (2.00%) high mild
  10 (10.00%) high severe

decode_frame - 0.5/throughput
                        time:   [110.67 µs 111.60 µs 112.89 µs]
                        thrpt:  [276.82 MiB/s 280.03 MiB/s 282.38 MiB/s]
                 change:
                        time:   [+18.814% +26.988% +36.096%] (p = 0.00 < 0.05)
                        thrpt:  [−26.523% −21.252% −15.835%]
                        Performance has regressed.
Found 14 outliers among 100 measurements (14.00%)
  14 (14.00%) high severe
```

ToDo: 
- [ ]  Implement multichannel specific unit tests
- [ ]  Add const generic parameters for max channel count and max block length to allow better buffer size optimization in applications where these parameters are known at compile time, and allows previous performance in the case of 1 channel is the max channel count by cutting out the temporary buffer mentioned above.